### PR TITLE
refactor: extract display_info() to deduplicate account formatting

### DIFF
--- a/src/claude.rs
+++ b/src/claude.rs
@@ -29,6 +29,19 @@ pub struct AuthStatus {
     pub subscription_type: Option<String>,
 }
 
+impl AuthStatus {
+    /// Returns a formatted account info string like "Name <email>" or just "email".
+    /// Returns None if neither display_name nor email is available.
+    pub fn display_info(&self) -> Option<String> {
+        match (&self.display_name, &self.email) {
+            (Some(name), Some(email)) => Some(format!("{} <{}>", name, email)),
+            (Some(name), None) => Some(name.clone()),
+            (None, Some(email)) => Some(email.clone()),
+            (None, None) => None,
+        }
+    }
+}
+
 /// Returns detailed authentication status for the given config directory.
 pub fn auth_status(config_dir: &Path) -> AuthStatus {
     let keychain = has_keychain_api_key(config_dir);

--- a/src/commands/env.rs
+++ b/src/commands/env.rs
@@ -14,20 +14,9 @@ pub fn run(alias: &str) -> Result<()> {
     );
     // stderr: user-facing messages (not captured by eval)
     let auth = claude::auth_status(&account.config_dir);
-    let account_info = match (&auth.display_name, &auth.email) {
-        (Some(name), Some(email)) => format!("{} <{}>", name, email),
-        (Some(name), None) => name.clone(),
-        (None, Some(email)) => email.clone(),
-        (None, None) => String::new(),
-    };
-    if account_info.is_empty() {
-        eprintln!("Switched to account: {}", alias.bold());
-    } else {
-        eprintln!(
-            "Switched to account: {}  {}",
-            alias.bold(),
-            account_info.dimmed()
-        );
+    match auth.display_info() {
+        Some(info) => eprintln!("Switched to account: {}  {}", alias.bold(), info.dimmed()),
+        None => eprintln!("Switched to account: {}", alias.bold()),
     }
     Ok(())
 }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -59,12 +59,9 @@ pub fn run(names_only: bool) -> Result<()> {
         };
 
         let auth = claude::auth_status(&account.config_dir);
-        let account_str = match (&auth.display_name, &auth.email) {
-            (Some(name), Some(email)) => format!("{} <{}>", name, email),
-            (Some(name), None) => name.clone(),
-            (None, Some(email)) => email.clone(),
-            (None, None) => account.config_dir.display().to_string(),
-        };
+        let account_str = auth
+            .display_info()
+            .unwrap_or_else(|| account.config_dir.display().to_string());
 
         let desc = account
             .description

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -89,12 +89,10 @@ fn print_summary(
         account.config_dir.display().to_string().red()
     };
 
-    let user_str = match (&auth.display_name, &auth.email) {
-        (Some(name), Some(email)) => format!("  {}", format!("{} <{}>", name, email).dimmed()),
-        (Some(name), None) => format!("  {}", name.as_str().dimmed()),
-        (None, Some(email)) => format!("  {}", email.as_str().dimmed()),
-        _ => String::new(),
-    };
+    let user_str = auth
+        .display_info()
+        .map(|info| format!("  {}", info.dimmed()))
+        .unwrap_or_default();
 
     println!(
         "{}{:<12} {}  [{}]{}",


### PR DESCRIPTION
AuthStatus::display_info() centralizes the repeated match pattern across env.rs, list.rs, and status.rs.