### PR TITLE
feat: symlink shared files across accounts and document the model

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ However, Claude Code only supports one account at a time. Even with multiple ter
 
 ccam removes that friction. Each terminal session can run a different Claude Code account simultaneously, making it seamless to distribute usage across accounts and get the most out of your subscriptions.
 
+## Overview
+
+### Account Switching Model
+
+**Default Account** (`ccam default <alias>`) — the account applied automatically whenever a new terminal session opens. Set it once, and every new terminal starts with that account active. Managed via shell integration.
+
+**Session Switch** (`ccam use <alias>`) — temporarily switches the account in the current shell session only. Useful when you want to use a different account without changing the default. The switch does not affect other terminal windows, and reverts to the default when you open a new session.
+
 ```
  New terminal           Current terminal        New terminal
  (default applies)      (ccam use)              (default applies)
@@ -17,6 +25,38 @@ ccam removes that friction. Each terminal session can run a different Claude Cod
 │                   │  │    (this session  │  │                   │
 └───────────────────┘  │     only)         │  └───────────────────┘
                        └───────────────────┘
+```
+
+### Shared files across accounts
+
+Giving each account its own `CLAUDE_CONFIG_DIR` isolates credentials, but it also separates files like `settings.json`, `CLAUDE.md`, and `plugins/` — meaning changes in one account don't carry over to others.
+
+ccam solves this by symlinking those files through a shared directory (`~/.claude-accounts/shared/`), which itself points to `~/.claude/`. Every account directory gets symlinks for the shared items, so all accounts read and write the same files.
+
+**Shared items:** `settings.json`, `CLAUDE.md`, `plugins/`
+
+```
+~/.claude/
+├── settings.json          # ← single source of truth (shared across all accounts)
+├── CLAUDE.md
+└── plugins/
+
+~/.claude-accounts/
+├── accounts.toml          # account registry (paths, metadata; no credentials)
+├── shared/
+│   ├── settings.json ──→  ~/.claude/settings.json   (symlink)
+│   ├── CLAUDE.md ──────→  ~/.claude/CLAUDE.md        (symlink)
+│   └── plugins/ ───────→  ~/.claude/plugins/         (symlink)
+├── account1/              # CLAUDE_CONFIG_DIR for account1
+│   ├── settings.json ──→  ../shared/settings.json    (symlink)
+│   ├── CLAUDE.md ──────→  ../shared/CLAUDE.md        (symlink)
+│   ├── plugins/ ───────→  ../shared/plugins/         (symlink)
+│   └── ...                # auth state, project history (per-account)
+└── account2/
+    ├── settings.json ──→  ../shared/settings.json    (symlink)
+    ├── CLAUDE.md ──────→  ../shared/CLAUDE.md        (symlink)
+    ├── plugins/ ───────→  ../shared/plugins/         (symlink)
+    └── ...
 ```
 
 ## Requirements
@@ -58,12 +98,6 @@ eval "$(ccam init bash)"
 fish_add_path "$HOME/.local/bin"
 ccam init fish | source
 ```
-
-## Account Switching Model
-
-**Default Account** (`ccam default <alias>`) — the account applied automatically whenever a new terminal session opens. Set it once, and every new terminal starts with that account active. Managed via shell integration.
-
-**Session Switch** (`ccam use <alias>`) — temporarily switches the account in the current shell session only. Useful when you want to use a different account without changing the default. The switch does not affect other terminal windows, and reverts to the default when you open a new session.
 
 ## Usage
 

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -20,6 +20,8 @@ pub fn run(
         "      {}",
         account.config_dir.display().to_string().dimmed()
     );
+    config::ensure_shared_symlinks()?;
+    config::setup_account_symlinks(&account.config_dir)?;
 
     if no_login {
         println!("[2/3] {}", "로그인 건너뜀 (--no-login)".yellow());

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,84 @@ pub fn accounts_dir() -> PathBuf {
         .join(".claude-accounts")
 }
 
+pub fn claude_dir() -> PathBuf {
+    home_dir().expect("home dir not found").join(".claude")
+}
+
+pub fn shared_dir() -> PathBuf {
+    accounts_dir().join("shared")
+}
+
+/// 공유 대상 항목 (settings.json, CLAUDE.md, plugins/)
+pub const SHARED_ITEMS: &[&str] = &["settings.json", "CLAUDE.md", "plugins"];
+
+fn is_symlink(path: &Path) -> bool {
+    path.symlink_metadata()
+        .map(|m| m.file_type().is_symlink())
+        .unwrap_or(false)
+}
+
+fn create_symlink_if_needed(link: &Path, target: &Path) -> Result<()> {
+    if is_symlink(link) || link.exists() {
+        return Ok(());
+    }
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(target, link).with_context(|| {
+        format!(
+            "symlink {} -> {} 생성 실패",
+            link.display(),
+            target.display()
+        )
+    })?;
+    Ok(())
+}
+
+/// ~/.claude-accounts/shared/ 에 ~/.claude/ 를 가리키는 심볼릭 링크를 설정합니다.
+/// ~/.claude/ 가 없으면 생성합니다.
+pub fn ensure_shared_symlinks() -> Result<()> {
+    let claude = claude_dir();
+    let shared = shared_dir();
+    fs::create_dir_all(&claude)?;
+    fs::create_dir_all(&shared)?;
+    for name in SHARED_ITEMS {
+        create_symlink_if_needed(&shared.join(name), &claude.join(name))?;
+    }
+    Ok(())
+}
+
+/// 계정 디렉토리에 ../shared/ 를 가리키는 심볼릭 링크를 설정합니다.
+/// account_dir 이 ~/.claude 자체인 경우 (--dir ~/.claude) 심볼릭 링크 불필요.
+pub fn setup_account_symlinks(account_dir: &Path) -> Result<()> {
+    let claude = claude_dir();
+    let canon_account = account_dir
+        .canonicalize()
+        .unwrap_or_else(|_| account_dir.to_path_buf());
+    let canon_claude = claude.canonicalize().unwrap_or_else(|_| claude.clone());
+    if canon_account == canon_claude {
+        return Ok(());
+    }
+    for name in SHARED_ITEMS {
+        let account_path = account_dir.join(name);
+        if is_symlink(&account_path) {
+            continue;
+        }
+        // 실제 파일/디렉토리가 있으면 ~/.claude/ 로 이동 후 제거
+        if account_path.exists() {
+            let claude_target = claude.join(name);
+            if !claude_target.exists() {
+                fs::rename(&account_path, &claude_target)
+                    .with_context(|| format!("{} 이동 실패", account_path.display()))?;
+            } else if account_path.is_dir() {
+                fs::remove_dir_all(&account_path)?;
+            } else {
+                fs::remove_file(&account_path)?;
+            }
+        }
+        create_symlink_if_needed(&account_path, &PathBuf::from("../shared").join(name))?;
+    }
+    Ok(())
+}
+
 pub fn accounts_file() -> PathBuf {
     accounts_dir().join("accounts.toml")
 }


### PR DESCRIPTION
- Add `ensure_shared_symlinks` and `setup_account_symlinks` to config.rs so that settings.json, CLAUDE.md, and plugins/ are shared via ~/.claude-accounts/shared/ → ~/.claude/ symlink chain
- Call both functions from `ccm add` after creating the account directory
- Update README: move Account Switching Model under an Overview section, add Shared files section with directory diagram