### PR TITLE
refactor: always delete config directory on remove, drop --purge flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,7 @@ ccam logout account1   # Logout (removes Keychain token)
 ### Remove an account
 
 ```bash
-ccam remove account1           # Unregister account
-ccam remove account1 --purge   # Unregister and delete config directory
+ccam remove account1   # Unregister account and delete config directory
 ```
 
 

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -3,22 +3,10 @@ use anyhow::Result;
 use colored::Colorize;
 use std::fs;
 
-pub fn run(alias: &str, purge: bool) -> Result<()> {
+pub fn run(alias: &str) -> Result<()> {
     let account = config::get_account(alias)?;
 
-    // Determine confirmation level
-    if purge {
-        println!("{}", "[경고] 이 작업은 되돌릴 수 없습니다.".red().bold());
-        println!(
-            "  '{}' 계정을 Keychain에서 로그아웃하고,\n  accounts.toml에서 제거하며,\n  디렉토리({})를 삭제합니다.",
-            alias,
-            account.config_dir.display()
-        );
-        if !confirm::confirm_yes("") {
-            println!("취소되었습니다.");
-            return Ok(());
-        }
-    } else if !confirm::confirm_yn(&format!("'{}' 계정을 제거하시겠습니까?", alias)) {
+    if !confirm::confirm_yn(&format!("'{}' 계정을 제거하시겠습니까?", alias)) {
         println!("취소되었습니다.");
         return Ok(());
     }
@@ -37,8 +25,8 @@ pub fn run(alias: &str, purge: bool) -> Result<()> {
     config::remove_account(alias)?;
     println!("accounts.toml에서 '{}' 제거 완료.", alias);
 
-    // Step 3: delete directory if --purge
-    if purge && account.config_dir.exists() {
+    // Step 3: delete config directory
+    if account.config_dir.exists() {
         fs::remove_dir_all(&account.config_dir)?;
         println!("디렉토리 삭제 완료: {}", account.config_dir.display());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,13 +36,8 @@ enum Command {
         names_only: bool,
     },
 
-    /// Remove an account
-    Remove {
-        alias: String,
-        /// Also delete the config directory
-        #[arg(long)]
-        purge: bool,
-    },
+    /// Remove an account and delete its config directory
+    Remove { alias: String },
 
     /// [Internal] Output `export CLAUDE_CONFIG_DIR=...` for eval
     #[command(name = "__env", hide = true)]
@@ -117,8 +112,8 @@ fn main() -> Result<()> {
             commands::list::run(names_only)?;
         }
 
-        Command::Remove { alias, purge } => {
-            commands::remove::run(&alias, purge)?;
+        Command::Remove { alias } => {
+            commands::remove::run(&alias)?;
         }
 
         Command::InternalEnv { alias } | Command::Env { alias } => {


### PR DESCRIPTION
ccam remove now always removes the account directory along with unregistering and logging out. The --purge flag is removed since it is no longer meaningful — once an account is removed from ccam, its directory cannot be managed through ccam anymore.