### PR TITLE
feat: fetch and display Claude user info per account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "ccam"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src/claude.rs
+++ b/src/claude.rs
@@ -81,6 +81,41 @@ pub fn logout(config_dir: &Path) -> Result<()> {
     Ok(())
 }
 
+/// User information returned by `claude auth status`.
+pub struct UserInfo {
+    pub email: String,
+    pub subscription_type: String,
+}
+
+/// Runs `claude auth status` and parses user info from its JSON output.
+/// Returns `None` if not logged in or the command fails.
+pub fn fetch_user_info(config_dir: &Path) -> Option<UserInfo> {
+    let claude = find_claude().ok()?;
+    let mut cmd = Command::new(&claude);
+    cmd.args(["auth", "status", "--json"]);
+    if !is_default_config_dir(config_dir) {
+        cmd.env("CLAUDE_CONFIG_DIR", config_dir);
+    }
+    let output = cmd.output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
+    if json.get("loggedIn").and_then(|v| v.as_bool()) != Some(true) {
+        return None;
+    }
+    let email = json.get("email")?.as_str()?.to_string();
+    let subscription_type = json
+        .get("subscriptionType")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown")
+        .to_string();
+    Some(UserInfo {
+        email,
+        subscription_type,
+    })
+}
+
 pub fn dir_keychain_service(config_dir: &Path) -> String {
     use sha2::{Digest, Sha256};
     use std::fmt::Write;

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -36,5 +36,19 @@ pub fn run(alias: &str, dir: Option<&PathBuf>, description: Option<&str>) -> Res
         default_tag,
     );
     claude::run(&account.config_dir)?;
+
+    // Best-effort: capture user info written to Keychain during login
+    if let Some(info) = claude::fetch_user_info(&account.config_dir) {
+        let _ = config::update_account_user_info(
+            alias,
+            Some(info.email.clone()),
+            Some(info.subscription_type.clone()),
+        );
+        eprintln!(
+            "      {} ({})",
+            info.email.dimmed(),
+            info.subscription_type.dimmed()
+        );
+    }
     Ok(())
 }

--- a/src/commands/env.rs
+++ b/src/commands/env.rs
@@ -13,10 +13,27 @@ pub fn run(alias: &str) -> Result<()> {
         account.config_dir.display()
     );
     // stderr: user-facing messages (not captured by eval)
-    eprintln!("Switched to account: {}", alias.bold());
-    if !claude::auth_status(&account.config_dir).keychain {
+    if claude::auth_status(&account.config_dir).keychain {
+        // Refresh stored user info on each switch (picks up logins done outside ccm)
+        if let Some(info) = claude::fetch_user_info(&account.config_dir) {
+            let _ = config::update_account_user_info(
+                alias,
+                Some(info.email.clone()),
+                Some(info.subscription_type.clone()),
+            );
+            eprintln!(
+                "* {} {} ({})",
+                alias.green().bold(),
+                info.email.dimmed(),
+                info.subscription_type
+            );
+        } else {
+            eprintln!("* {}", alias.green().bold());
+        }
+    } else {
+        eprintln!("* {}", alias.green().bold());
         eprintln!(
-            "{} 로그인이 필요합니다. {} 를 실행하세요.",
+            "  {} 로그인이 필요합니다. {} 를 실행하세요.",
             "⚠".yellow(),
             "claude".cyan()
         );

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -47,18 +47,12 @@ pub fn run(names_only: bool) -> Result<()> {
 
     for (alias, account) in &accounts {
         let is_default = cfg.default.as_deref() == Some(alias.as_str());
+        let prefix = if is_default { "* " } else { "  " };
         let alias_str = if is_default {
             alias.cyan().bold().to_string()
         } else {
             alias.bold().to_string()
         };
-        let default_tag = if is_default {
-            format!(" {}", "(default)".truecolor(100, 150, 160))
-        } else {
-            String::new()
-        };
-
-        let account_str = account.config_dir.display().to_string();
 
         let desc = account
             .description
@@ -67,10 +61,11 @@ pub fn run(names_only: bool) -> Result<()> {
             .unwrap_or_default();
 
         println!(
-            "  {}{} {}{}",
+            "{}{} {}{}{}",
+            prefix,
             alias_str,
-            default_tag,
-            account_str.dimmed(),
+            account.display_name().dimmed(),
+            account.sub_tag(),
             desc
         );
     }

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -20,7 +20,10 @@ pub fn run_current(short: bool) -> Result<()> {
                 }
                 // short 모드에서 미등록 경로면 아무것도 출력하지 않음
             } else if let Some(a) = alias {
-                println!("{} ({})", a.green().bold(), dir);
+                let account = cfg.accounts.get(a);
+                let name = account.map(|ac| ac.display_name()).unwrap_or("");
+                let sub_tag = account.map(|ac| ac.sub_tag()).unwrap_or_default();
+                println!("* {} {}{}", a.green().bold(), name.dimmed(), sub_tag);
             } else {
                 println!("{} (ccm 미등록 경로)", dir.yellow());
             }
@@ -82,13 +85,22 @@ fn print_summary(
         "미로그인".yellow()
     };
 
-    let dir_str = if dir_exists {
-        account.config_dir.display().to_string().normal()
+    let display = if dir_exists {
+        account.display_name().normal()
     } else {
-        account.config_dir.display().to_string().red()
+        account.display_name().red()
     };
 
-    println!("{}{:<12} {}  [{}]", prefix, alias.bold(), dir_str, auth_str,);
+    let sub_tag = account.sub_tag();
+
+    println!(
+        "{}{:<12} {}{}  [{}]",
+        prefix,
+        alias.bold(),
+        display,
+        sub_tag,
+        auth_str,
+    );
 }
 
 fn print_detailed(
@@ -123,4 +135,8 @@ fn print_detailed(
         "✗".dimmed()
     };
     println!("  인증    Keychain {}", keychain_icon);
+    if let Some(email) = &account.email {
+        let sub = account.subscription_type.as_deref().unwrap_or("unknown");
+        println!("  계정    {} ({})", email, sub);
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result, bail};
 use chrono::Utc;
+use colored::Colorize;
 use dirs::home_dir;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -12,6 +13,25 @@ pub struct Account {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     pub added_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subscription_type: Option<String>,
+}
+
+impl Account {
+    /// Returns the email if known, otherwise an empty string.
+    pub fn display_name(&self) -> &str {
+        self.email.as_deref().unwrap_or("")
+    }
+
+    /// Returns a formatted, colored subscription suffix like ` (pro)`, or empty string.
+    pub fn sub_tag(&self) -> String {
+        self.subscription_type
+            .as_deref()
+            .map(|s| format!(" ({})", s.truecolor(100, 150, 160)))
+            .unwrap_or_default()
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -153,6 +173,8 @@ pub fn add_account(
         config_dir: expanded,
         description,
         added_at: Utc::now().to_rfc3339(),
+        email: None,
+        subscription_type: None,
     };
     cfg.accounts.insert(alias.to_string(), account.clone());
     save(&cfg)?;
@@ -192,6 +214,21 @@ pub fn set_default(alias: Option<&str>) -> Result<()> {
         }
         None => cfg.default = None,
     }
+    save(&cfg)
+}
+
+pub fn update_account_user_info(
+    alias: &str,
+    email: Option<String>,
+    subscription_type: Option<String>,
+) -> Result<()> {
+    let mut cfg = load()?;
+    let account = cfg
+        .accounts
+        .get_mut(alias)
+        .with_context(|| format!("account '{}' not found", alias))?;
+    account.email = email;
+    account.subscription_type = subscription_type;
     save(&cfg)
 }
 


### PR DESCRIPTION
Run `claude auth status --json` after login to capture email and subscription type, storing them in accounts.toml. On `ccm use`, refresh user info if the account is already logged in (picks up logins done outside ccm).

Display changes:
- All commands now show email + (subscription) instead of path
- Unlogged-in accounts show alias only, no path fallback
- Consistent `*` prefix for active/default account across list, status, active, and use commands
- Account.display_name() and Account.sub_tag() helpers centralize display logic