### PR TITLE
fix: preserve existing login for accounts using default ~/.claude dir

### DIFF
--- a/src/commands/env.rs
+++ b/src/commands/env.rs
@@ -8,10 +8,16 @@ use colored::Colorize;
 pub fn run(alias: &str) -> Result<()> {
     let account = config::get_account(alias)?;
     // stdout: only the export statement for eval
-    println!(
-        "export CLAUDE_CONFIG_DIR=\"{}\"",
-        account.config_dir.display()
-    );
+    // If the account uses the default ~/.claude directory, unset CLAUDE_CONFIG_DIR so Claude Code
+    // uses its built-in default keychain key ("Claude Code-credentials" without hash suffix).
+    if claude::is_default_config_dir(&account.config_dir) {
+        println!("unset CLAUDE_CONFIG_DIR");
+    } else {
+        println!(
+            "export CLAUDE_CONFIG_DIR=\"{}\"",
+            account.config_dir.display()
+        );
+    }
     // stderr: user-facing messages (not captured by eval)
     if claude::auth_status(&account.config_dir).keychain {
         // Refresh stored user info on each switch (picks up logins done outside ccm)

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -25,8 +25,14 @@ pub fn run(alias: &str) -> Result<()> {
     config::remove_account(alias)?;
     println!("accounts.toml에서 '{}' 제거 완료.", alias);
 
-    // Step 3: delete config directory
-    if account.config_dir.exists() {
+    // Step 3: delete config directory (skip if it's the default ~/.claude)
+    if claude::is_default_config_dir(&account.config_dir) {
+        println!(
+            "{} 기본 디렉토리({})는 삭제하지 않습니다.",
+            "참고:".yellow(),
+            account.config_dir.display()
+        );
+    } else if account.config_dir.exists() {
         fs::remove_dir_all(&account.config_dir)?;
         println!("디렉토리 삭제 완료: {}", account.config_dir.display());
     }


### PR DESCRIPTION
When an account's config_dir is ~/.claude, do not set CLAUDE_CONFIG_DIR so Claude Code uses its built-in default keychain key ("Claude Code-credentials" without hash suffix).

Also skip deleting the config directory on remove when it is ~/.claude.