### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.0] - 2026-03-12
+
+### Added
+- `--yes / -y` flag for `remove` command to skip confirmation prompt
+- Shell wrappers (bash/zsh/fish) now eval `remove` output to apply `CLAUDE_CONFIG_DIR` changes in the current shell session
+- `rm` alias for `remove` in all shell wrappers
+- `sorted_accounts()` method on `AccountsConfig` to consolidate sort-by-alias patterns
+- SHA256 checksum files generated alongside release tarballs
+- Comprehensive test suite: unit and integration tests for `remove`, `use`, `status`, shell integration, shared-path scenarios, and display formatting
+
+### Changed
+- `remove`: auto-reassigns default to alphabetically first remaining account after deletion
+- `add`: auto-default assignment now lives in `config::add_account()` (previously scattered)
+- Account line display unified across `ls`, `use`, and `active` commands (consistent prefix and color)
+- Release workflow now gates build on passing tests (`cargo fmt`, `clippy --all-targets`, `cargo test --locked`)
+- Release triggered on master push (Cargo.toml version change) instead of tag push
+- Fixed `ccm` → `ccam` typo in user-facing hints (`list`, `keychain`)
+
+### Fixed
+- `remove`: skip keychain logout and directory cleanup when `config_dir` is shared by another account
+- `status` / `active`: resolve active account deterministically when multiple accounts share the same `config_dir` (priority: default account first, then alphabetically first)
+- `dir_keychain_service`: normalize trailing slash before hashing so `/path/` and `/path` map to the same keychain service name
+- Shell `rm`/`remove` wrapper: restored interactive stdin by replacing command substitution with a temp file, so confirmation prompts work correctly
+
 ## [0.3.1] - 2026-03-08
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "ccam"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccam"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 description = "Claude Code multi-account manager"
 


### PR DESCRIPTION
## Summary

- Bump `Cargo.toml` version `0.3.1` → `0.4.0`
- Update `CHANGELOG.md` with all changes since v0.3.1

## Changes included in this release

### Fixed
- `remove`: skip keychain logout and dir cleanup when `config_dir` is shared by another account
- `status`/`active`: deterministic active account resolution for shared `config_dir`
- `dir_keychain_service`: normalize trailing slash before hashing
- Shell `rm`/`remove` wrapper: restore interactive stdin (replace command substitution with temp file)

### Added
- `--yes / -y` flag for `remove` to skip confirmation
- Shell wrappers eval `remove` output to update `CLAUDE_CONFIG_DIR` in current session
- `rm` alias for `remove` in bash/zsh/fish
- Comprehensive test suite (126 tests across remove, use, status, shell, shared-path, display)
- SHA256 checksums in release artifacts

### Changed
- Unified account line display across `ls`, `use`, `active`
- Auto-default assignment moved into `config::add_account()`
- Release workflow gates build on passing tests; triggered by Cargo.toml version bump on master